### PR TITLE
Mask `com.sun.mail.` classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,4 +78,16 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <maskClasses>com.sun.mail.</maskClasses>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
The `javax-mail-api` plugin also provides these same classes, so we need to mask them to avoid conflicts.