### PR TITLE
Run `FileTypeMap` with context class loader

### DIFF
--- a/src/main/java/io/jenkins/plugins/jakarta/activation/DelegatingFileTypeMap.java
+++ b/src/main/java/io/jenkins/plugins/jakarta/activation/DelegatingFileTypeMap.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.jakarta.activation;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jakarta.activation.FileTypeMap;
+import java.io.File;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public class DelegatingFileTypeMap extends FileTypeMap {
+    private final FileTypeMap delegate;
+
+    public DelegatingFileTypeMap(@NonNull FileTypeMap delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    private static final <T> T runWithContextClassLoader(Supplier<T> supplier) {
+        Thread t = Thread.currentThread();
+        ClassLoader orig = t.getContextClassLoader();
+        t.setContextClassLoader(DelegatingFileTypeMap.class.getClassLoader());
+        try {
+            return supplier.get();
+        } finally {
+            t.setContextClassLoader(orig);
+        }
+    }
+
+    @Override
+    public String getContentType(File file) {
+        return runWithContextClassLoader(() -> delegate.getContentType(file));
+    }
+
+    @Override
+    public String getContentType(String filename) {
+        return runWithContextClassLoader(() -> delegate.getContentType(filename));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jakarta/activation/FileTypeMapInitializer.java
+++ b/src/main/java/io/jenkins/plugins/jakarta/activation/FileTypeMapInitializer.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins.jakarta.activation;
+
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import jakarta.activation.FileTypeMap;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public class FileTypeMapInitializer {
+
+    @Initializer(after = InitMilestone.PLUGINS_PREPARED, before = InitMilestone.PLUGINS_STARTED)
+    public static synchronized void init() {
+        Thread t = Thread.currentThread();
+        ClassLoader orig = t.getContextClassLoader();
+        t.setContextClassLoader(FileTypeMapInitializer.class.getClassLoader());
+        try {
+            // Getting the default file type map fetches a per-thread-context-class-loader default.
+            // Setting the default file type map removes the per-thread-context-class-loader file type map.
+            FileTypeMap.setDefaultFileTypeMap(new DelegatingFileTypeMap(FileTypeMap.getDefaultFileTypeMap()));
+        } finally {
+            t.setContextClassLoader(orig);
+        }
+    }
+}


### PR DESCRIPTION
Like #5 but for `FileTypeMap`. I haven't observed any problems with `FileTypeMap` yet, but it seems to work the same way as `CommandMap`, so might as well give it the same treatment.