### PR TITLE
Upgrade Jakarta Mail from 2.0.1 to 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,21 +42,33 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.sun.mail</groupId>
-      <artifactId>jakarta.mail</artifactId>
-      <version>2.0.1</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jakarta-activation-api</artifactId>
+      <version>2.1.3-1</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
+      <version>2.1.3</version>
       <exclusions>
         <!-- Provided by jakarta-activation-api plugin -->
         <exclusion>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>jakarta.activation</artifactId>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>jakarta-activation-api</artifactId>
-      <version>2.0.1-3</version>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>angus-mail</artifactId>
+      <version>2.0.3</version>
+      <exclusions>
+        <!-- Provided by jakarta-activation-api plugin -->
+        <exclusion>
+          <groupId>org.eclipse.angus</groupId>
+          <artifactId>angus-activation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -72,17 +84,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <!-- The javax-mail-api plugin also provides these same classes, so we need to mask them to avoid conflicts. -->
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <maskClasses>com.sun.mail.</maskClasses>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jakarta-activation-api-plugin/pull/61 and https://github.com/jakartaee/mail-api/pull/701. See this [YouTube video with more information](https://www.youtube.com/watch?v=gsNwC7K8URk).