### PR TITLE
Use Jakarta Mail API 2.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jakarta-activation-api</artifactId>
-      <!-- TODO: replace when plugin is released https://github.com/jenkinsci/jakarta-activation-api-plugin/pull/95 -->
-      <!-- TODO: replace when plugin is released https://github.com/jenkinsci/jakarta-activation-api-plugin/pull/94 -->
-      <version>2.1.3-3-rc115.a_e2cfee2f3b_1</version>
+      <version>2.1.4-1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.mail</groupId>


### PR DESCRIPTION
## Use Jakarta mail API 2.1.5

Jakarta mail API 2.1.5 released in Sep 2025.

* https://github.com/jakartaee/mail-api/releases/tag/2.1.5
* https://github.com/jakartaee/mail-api/releases/tag/2.1.4

Includes pull request:

* #123 

### Testing done

* Confirmed automated tests pass
* Confirmed tests pass in plugin BOM

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
